### PR TITLE
remove references to gazebo colors which aren't referenced in urdf

### DIFF
--- a/model/robots/common/xacro/arm/arm.xacro
+++ b/model/robots/common/xacro/arm/arm.xacro
@@ -19,7 +19,6 @@
                     ixx="${ShoulderPitchLinkInertia_IXX}" ixy="${ShoulderPitchLinkInertia_IXY}" ixz="${ShoulderPitchLinkInertia_IXZ}"
                     iyy="${ShoulderPitchLinkInertia_IYY}" iyz="${ShoulderPitchLinkInertia_IYZ}" izz="${ShoulderPitchLinkInertia_IZZ}"
                     visual_mesh="${mesh_root}/arms/aj1_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/arms/aj1_${prefix}.dae" />
 
     <xacro:standard_link name="${ShoulderRollLinkName}"
@@ -29,7 +28,6 @@
                     iyy="${ShoulderRollLinkInertia_IYY}" iyz="${ShoulderRollLinkInertia_IYZ}" izz="${ShoulderRollLinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/arms/aj2_${prefix}.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/arms/aj2_${prefix}.dae" />
 
     <xacro:standard_link name="${ShoulderYawLinkName}"
@@ -39,7 +37,6 @@
                     iyy="${ShoulderYawLinkInertia_IYY}" iyz="${ShoulderYawLinkInertia_IYZ}" izz="${ShoulderYawLinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/arms/aj3_${prefix}.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/arms/aj3_${prefix}.dae" />
 
     <xacro:standard_link name="${ElbowPitchLinkName}"
@@ -49,7 +46,6 @@
                     iyy="${ElbowPitchLinkInertia_IYY}" iyz="${ElbowPitchLinkInertia_IYZ}" izz="${ElbowPitchLinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/arms/aj4_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/arms/aj4_${prefix}.dae" />
 
     <xacro:revolute_joint_ex jointName="${ShoulderPitchJointName}"
@@ -112,7 +108,6 @@
                     iyy="${ForearmYawLinkInertia_IYY}" iyz="${ForearmYawLinkInertia_IYZ}" izz="${ForearmYawLinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/arms/aj5_${prefix}.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/arms/aj5_${prefix}.dae" />
 
     <xacro:standard_link name="${WristRollLinkName}"
@@ -122,7 +117,6 @@
                     iyy="${WristRollLinkInertia_IYY}" iyz="${WristRollLinkInertia_IYZ}" izz="${WristRollLinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/arms/aj6_${prefix}.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/arms/aj6_${prefix}.dae" />
 
     <xacro:standard_link name="${WristPitchLinkName}"
@@ -132,7 +126,6 @@
                     iyy="${PalmInertia_IYY}" iyz="${PalmInertia_IYZ}" izz="${PalmInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/arms/palm_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/arms/palm_${prefix}.dae"/>
 
     <xacro:revolute_joint_ex jointName="${ForearmYawJointName}"

--- a/model/robots/common/xacro/generic_models.xacro
+++ b/model/robots/common/xacro/generic_models.xacro
@@ -5,7 +5,7 @@
     <actuator name="${name}" type="${api}"/>
   </xacro:macro>
 
-  <xacro:macro name="standard_link" params="name mass origin_rpy origin_xyz ixx ixy ixz iyy iyz izz visual_mesh material collision_mesh">
+  <xacro:macro name="standard_link" params="name mass origin_rpy origin_xyz ixx ixy ixz iyy iyz izz visual_mesh collision_mesh">
     <link name="${name}">
       <inertial>
         <mass value="${mass}"/>
@@ -19,7 +19,6 @@
             <mesh filename="${visual_mesh}"/>
           </geometry>
           <origin rpy="0.0 0.0 0.0" xyz="0.0 0.0 0.0"/>
-          <material name="${material}"/>
         </visual>
         <collision>
         <geometry>
@@ -56,7 +55,7 @@
   </xacro:macro>
 
   <xacro:macro name="link_box_collision_mesh_visual"
-          params="name width height depth mass inertial_xyz inertial_rpy ixx ixy ixz iyy iyz izz visual_mesh material box_xyz box_rpy">
+          params="name width height depth mass inertial_xyz inertial_rpy ixx ixy ixz iyy iyz izz visual_mesh box_xyz box_rpy">
     <link name="${name}">
       <inertial>
         <mass value="${mass}" />
@@ -70,7 +69,6 @@
           <mesh filename="${visual_mesh}"/>
         </geometry>
         <origin rpy="0 0 0" xyz="0 0 0"/>
-        <material name="${material}"/>
       </visual>
       <collision>
         <geometry>

--- a/model/robots/common/xacro/head/head.xacro
+++ b/model/robots/common/xacro/head/head.xacro
@@ -24,7 +24,6 @@
                         ixx="${LowerNeckPitchLinkInertia_IXX}" ixy="${LowerNeckPitchLinkInertia_IXY}" ixz="${LowerNeckPitchLinkInertia_IXZ}"
                         iyy="${LowerNeckPitchLinkInertia_IYY}" iyz="${LowerNeckPitchLinkInertia_IYZ}" izz="${LowerNeckPitchLinkInertia_IZZ}"
                         visual_mesh="${mesh_root}/head/neckj1.dae"
-                        material="White"
                         collision_mesh="${mesh_root}/head/neckj1.dae"/>
 
     <xacro:standard_link name="${NeckYawLinkName}"
@@ -34,7 +33,6 @@
                         ixx="${NeckYawLinkInertia_IXX}" ixy="${NeckYawLinkInertia_IXY}" ixz="${NeckYawLinkInertia_IXZ}"
                         iyy="${NeckYawLinkInertia_IYY}" iyz="${NeckYawLinkInertia_IYZ}" izz="${NeckYawLinkInertia_IZZ}"
                         visual_mesh="${mesh_root}/head/neckj2.dae"
-                        material="White"
                         collision_mesh="${mesh_root}/head/neckj2.dae" />
 
     <xacro:standard_link name="${UpperNeckPitchLinkName}"
@@ -44,7 +42,6 @@
                        iyy="${UpperNeckPitchLinkInertia_IYY}" iyz="${UpperNeckPitchLinkInertia_IYZ}" izz="${UpperNeckPitchLinkInertia_IZZ}"
                        origin_rpy="0 0 0"
                        visual_mesh="${mesh_root}/head/head_multisense_no_visor.dae"
-                       material="White"
                        collision_mesh="${mesh_root}/head/head_multisense_no_visor.dae"/>
 
     <xacro:revolute_joint_ex jointName="${LowerNeckPitchJointName}"

--- a/model/robots/common/xacro/index_finger/index_finger.xacro
+++ b/model/robots/common/xacro/index_finger/index_finger.xacro
@@ -17,7 +17,6 @@
                     iyy="${IndexFingerPitch1LinkInertia_IYY}" iyz="${IndexFingerPitch1LinkInertia_IYZ}" izz="${IndexFingerPitch1LinkInertia_IZZ}"
                     origin_rpy="0 0 0" 
                     visual_mesh="${mesh_root}/fingers/indexj1_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/indexj1_${prefix}.dae"/>
 
     <xacro:standard_link name="${IndexFingerPitch2LinkName}" 
@@ -27,7 +26,6 @@
                     iyy="${IndexFingerPitch2LinkInertia_IYY}" iyz="${IndexFingerPitch2LinkInertia_IYZ}" izz="${IndexFingerPitch2LinkInertia_IZZ}"
                     origin_rpy="0 0 0" 
                     visual_mesh="${mesh_root}/fingers/indexj2_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/indexj2_${prefix}.dae"/>
 
     <xacro:standard_link name="${IndexFingerPitch3LinkName}" 
@@ -37,7 +35,6 @@
                     iyy="${IndexFingerPitch3LinkInertia_IYY}" iyz="${IndexFingerPitch3LinkInertia_IYZ}" izz="${IndexFingerPitch3LinkInertia_IZZ}"
                     origin_rpy="0 0 0" 
                     visual_mesh="${mesh_root}/fingers/indexj3_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/indexj3_${prefix}.dae"/>
 
     <xacro:revolute_joint jointName="${IndexFingerPitch1JointName}" 

--- a/model/robots/common/xacro/leg/leg.xacro
+++ b/model/robots/common/xacro/leg/leg.xacro
@@ -18,7 +18,6 @@
                     ixx="${HipYawLinkInertia_IXX}" ixy="${HipYawLinkInertia_IXY}" ixz="${HipYawLinkInertia_IXZ}"
                     iyy="${HipYawLinkInertia_IYY}" iyz="${HipYawLinkInertia_IYZ}" izz="${HipYawLinkInertia_IZZ}"
                     visual_mesh="${mesh_root}/legs/lj1_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/legs/lj1_${prefix}.dae"/>
 
     <xacro:standard_link name="${HipRollLinkName}"
@@ -28,7 +27,6 @@
                     iyy="${HipRollLinkInertia_IYY}" iyz="${HipRollLinkInertia_IYZ}" izz="${HipRollLinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/legs/lj2_${prefix}.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/legs/lj2_${prefix}.dae"/>
 
     <xacro:standard_link name="${HipPitchLinkName}"
@@ -38,7 +36,6 @@
                     iyy="${HipPitchLinkInertia_IYY}" iyz="${HipPitchLinkInertia_IYZ}" izz="${HipPitchLinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/legs/lj3_${prefix}.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/legs/lj3_${prefix}.dae"/>
 
     <xacro:standard_link name="${KneePitchLinkName}"
@@ -48,7 +45,6 @@
                     iyy="${KneePitchLinkInertia_IYY}" iyz="${KneePitchLinkInertia_IYZ}" izz="${KneePitchLinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/legs/lj4_${prefix}.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/legs/lj4_${prefix}.dae"/>
 
     <xacro:standard_link name="${AnklePitchLinkName}"
@@ -58,7 +54,6 @@
                     iyy="${AnklePitchLinkInertia_IYY}" iyz="${AnklePitchLinkInertia_IYZ}" izz="${AnklePitchLinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/legs/lj5.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/legs/lj5.dae"/>
 
     <xacro:link_box_collision_mesh_visual name="${AnkleRollLinkName}"
@@ -68,7 +63,6 @@
                     iyy="${FootInertia_IYY}" iyz="${FootInertia_IYZ}" izz="${FootInertia_IZZ}"
                     inertial_rpy="0 0 0"
                     visual_mesh="${mesh_root}/legs/foot.dae"
-                    material="White"
                     width="0.27"
                     height="0.16"
                     depth="0.064"

--- a/model/robots/common/xacro/middle_finger/middle_finger.xacro
+++ b/model/robots/common/xacro/middle_finger/middle_finger.xacro
@@ -17,7 +17,6 @@
                     iyy="${MiddleFingerPitch1LinkInertia_IYY}" iyz="${MiddleFingerPitch1LinkInertia_IYZ}" izz="${MiddleFingerPitch1LinkInertia_IZZ}"
                     origin_rpy="0 0 0" 
                     visual_mesh="${mesh_root}/fingers/middlej1_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/middlej1_${prefix}.dae"/>
 
     <xacro:standard_link name="${MiddleFingerPitch2LinkName}" 
@@ -27,7 +26,6 @@
                     iyy="${MiddleFingerPitch2LinkInertia_IYY}" iyz="${MiddleFingerPitch2LinkInertia_IYZ}" izz="${MiddleFingerPitch2LinkInertia_IZZ}"
                     origin_rpy="0 0 0" 
                     visual_mesh="${mesh_root}/fingers/middlej2_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/middlej2_${prefix}.dae"/>
 
     <xacro:standard_link name="${MiddleFingerPitch3LinkName}" 
@@ -37,7 +35,6 @@
                     iyy="${MiddleFingerPitch3LinkInertia_IYY}" iyz="${MiddleFingerPitch3LinkInertia_IYZ}" izz="${MiddleFingerPitch3LinkInertia_IZZ}"
                     origin_rpy="0 0 0" 
                     visual_mesh="${mesh_root}/fingers/middlej3_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/middlej3_${prefix}.dae"/>
 
     <xacro:revolute_joint jointName="${MiddleFingerPitch1JointName}" 

--- a/model/robots/common/xacro/pelvis/pelvis.xacro
+++ b/model/robots/common/xacro/pelvis/pelvis.xacro
@@ -8,7 +8,7 @@
                         ixx="0.11866378" ixy="-0.000143482" ixz="0.003271293"
                         iyy="0.097963425" iyz="0.002159545" izz="0.083854638"
                         origin_rpy="0 0 0"
-                        visual_mesh="${mesh_root}/pelvis/pelvis.dae" material="White"
+                        visual_mesh="${mesh_root}/pelvis/pelvis.dae"
                         collision_mesh="${mesh_root}/pelvis/pelvis.dae"/>
     </xacro:macro>
 

--- a/model/robots/common/xacro/pinky_finger/pinky_finger.xacro
+++ b/model/robots/common/xacro/pinky_finger/pinky_finger.xacro
@@ -17,7 +17,6 @@
                     iyy="${PinkyPitch1LinkInertia_IYY}" iyz="${PinkyPitch1LinkInertia_IYZ}" izz="${PinkyPitch1LinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/fingers/pinkyj1_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/pinkyj1_${prefix}.dae"/>
 
     <xacro:standard_link name="${PinkyPitch2LinkName}"
@@ -27,7 +26,6 @@
                     iyy="${PinkyPitch2LinkInertia_IYY}" iyz="${PinkyPitch2LinkInertia_IYZ}" izz="${PinkyPitch2LinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/fingers/pinkyj2_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/pinkyj2_${prefix}.dae"/>
 
     <xacro:standard_link name="${PinkyPitch3LinkName}"
@@ -37,7 +35,6 @@
                     iyy="${PinkyPitch3LinkInertia_IYY}" iyz="${PinkyPitch3LinkInertia_IYZ}" izz="${PinkyPitch3LinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/fingers/pinkyj3_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/pinkyj3_${prefix}.dae"/>
 
     <xacro:revolute_joint jointName="${PinkyPitch1JointName}"

--- a/model/robots/common/xacro/thumb/thumb.xacro
+++ b/model/robots/common/xacro/thumb/thumb.xacro
@@ -16,7 +16,6 @@
                     iyy="${ThumbRollLinkInertia_IYY}" iyz="${ThumbRollLinkInertia_IYZ}" izz="${ThumbRollLinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/fingers/thumbj1_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/thumbj1_${prefix}.dae"/>
 
     <xacro:standard_link name="${ThumbPitch1LinkName}"
@@ -26,7 +25,6 @@
                     iyy="${ThumbPitch1LinkInertia_IYY}" iyz="${ThumbPitch1LinkInertia_IYZ}" izz="${ThumbPitch1LinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/fingers/thumbj2_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/thumbj2_${prefix}.dae"/>
 
     <xacro:standard_link name="${ThumbPitch2LinkName}"
@@ -36,7 +34,6 @@
                     iyy="${ThumbPitch2LinkInertia_IYY}" iyz="${ThumbPitch2LinkInertia_IYZ}" izz="${ThumbPitch2LinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/fingers/thumbj3_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/thumbj3_${prefix}.dae"/>
 
     <xacro:standard_link name="${ThumbPitch3LinkName}"
@@ -46,7 +43,6 @@
                     iyy="${ThumbPitch3LinkInertia_IYY}" iyz="${ThumbPitch3LinkInertia_IYZ}" izz="${ThumbPitch3LinkInertia_IZZ}"
                     origin_rpy="0 0 0"
                     visual_mesh="${mesh_root}/fingers/thumbj4_${prefix}.dae"
-                    material="Gold"
                     collision_mesh="${mesh_root}/fingers/thumbj4_${prefix}.dae"/>
 
     <xacro:revolute_joint jointName="${ThumbRollJointName}"

--- a/model/robots/common/xacro/waist/waist.xacro
+++ b/model/robots/common/xacro/waist/waist.xacro
@@ -55,7 +55,6 @@
                     ixx="${TorsoYawLinkInertia_IXX}" ixy="${TorsoYawLinkInertia_IXY}" ixz="${TorsoYawLinkInertia_IXZ}"
                     iyy="${TorsoYawLinkInertia_IYY}" iyz="${TorsoYawLinkInertia_IYZ}" izz="${TorsoYawLinkInertia_IZZ}"
                     visual_mesh="${mesh_root}/torso/torsoyaw.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/torso/torsoyaw.dae" />
 
     <xacro:standard_link name="${TorsoPitchLinkName}"
@@ -65,7 +64,6 @@
                     ixx="${TorsoPitchLinkInertia_IXX}" ixy="${TorsoPitchLinkInertia_IXY}" ixz="${TorsoPitchLinkInertia_IXZ}"
                     iyy="${TorsoPitchLinkInertia_IYY}" iyz="${TorsoPitchLinkInertia_IYZ}" izz="${TorsoPitchLinkInertia_IZZ}"
                     visual_mesh="${mesh_root}/torso/torsopitch.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/torso/torsopitch.dae" />
 
     <xacro:standard_link name="${TorsoRollLinkName}"
@@ -75,7 +73,6 @@
                     origin_rpy="0 0 0"
                     origin_xyz="${TorsoRollLinkComPosition}"
                     visual_mesh="${mesh_root}/torso/torso.dae"
-                    material="White"
                     collision_mesh="${mesh_root}/torso/torso.dae" />
 
     <xacro:make_waist_common waist_root_link="${waist_root_link}"/>


### PR DESCRIPTION
The urdf had a series of color tags:


    <material = 'Gold'>

But Gold isn't defined because the use of these colors was broken by 485b59e4036b574286c72c7e8cbea9c5129e7b52
that commit removed materials.xacro from valkyrie_A_sim.xacro

This causes the tiny-xml urdf parser to fail

@jlack1987 : did you mean to do the above? Alternatively you could add back in the material.xacro file