### PR TITLE
Add valkyrie_sim_harnessed.xacro

### DIFF
--- a/model/robots/valkyrie_sim_harnessed.xacro
+++ b/model/robots/valkyrie_sim_harnessed.xacro
@@ -1,0 +1,77 @@
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="valkyrie">
+
+    <xacro:property name="mesh_root" value="package://val_description/model/meshes"/>
+    <xacro:include filename="$(find val_description)/model/robots/common/xacro/generic_models.xacro" />
+    <xacro:include filename="$(find val_description)/model/materials/materials.xacro" />
+    <xacro:include filename="$(find val_description)/model/robots/common/xacro/common_bodies.xacro" />
+    <xacro:include filename="$(find val_description)/model/robots/common/xacro/valkyrie_base_sim.xacro"/>
+    <xacro:include filename="$(find val_description)/model/urdf/multisense_sl.urdf" />
+    <xacro:include filename="$(find val_description)/common/xacro/serial_numbers/valkyrie_A_serials.xacro"/>
+    <xacro:include filename="$(find val_description)/common/xacro/dev_ports/valkyrie_gazebo_ports.xacro"/>
+    <xacro:include filename="$(find val_description)/common/xacro/api/valkyrie_sim_api.xacro"/>
+
+    <gazebo>
+      <plugin filename="libgazebo_ros_harness.so" name="harness">
+
+        <joint name="harness_joint" type="prismatic">
+          <pose>0 0 0 0 0 0</pose>
+          <parent>world</parent>
+          <child>${TorsoRollLinkName}</child>
+          <axis>
+            <xyz>0 0 1</xyz>
+            <dynamics>
+              <damping>10</damping>
+            </dynamics>
+            <limit>
+              <lower>-1.5</lower>
+              <upper>1.5</upper>
+              <effort>10000</effort>
+              <velocity>-1</velocity>
+              <stiffness>0</stiffness>
+              <dissipation>0</dissipation>
+            </limit>
+          </axis>
+          <physics>
+            <ode>
+              <implicit_spring_damper>1</implicit_spring_damper>
+              <limit>
+                <cfm>0.0</cfm>
+                <erp>0.0</erp>
+              </limit>
+            </ode>
+          </physics>
+        </joint>
+
+        <!-- The joint that raises or lowers the harness -->
+        <winch>
+          <joint>harness_joint</joint>
+
+          <!-- PID value for velocity control of the winch. These values
+               are tuned to work with this box model. -->
+          <pos_pid>
+            <p>1e6</p>
+            <i>0</i>
+            <d>0</d>
+            <i_min>0</i_min>
+            <i_max>0</i_max>
+            <cmd_min>-1e4</cmd_min>
+            <cmd_max>1e4</cmd_max>
+          </pos_pid>
+          <vel_pid>
+            <p>1e6</p>
+            <i>0</i>
+            <d>0</d>
+            <i_min>0</i_min>
+            <i_max>0</i_max>
+            <cmd_min>0</cmd_min>
+            <cmd_max>1e4</cmd_max>
+          </vel_pid>
+        </winch>
+
+        <!-- Joint to detach. Once the joint is detached, it cannot be
+             reattached. This must be a joint specified within the
+             body of this plugin. -->
+        <detach>harness_joint</detach>
+      </plugin>
+    </gazebo>
+</robot>


### PR DESCRIPTION
This provides an alternative to the `val_sim_pinned` model that uses the new harness plugin introduced in https://github.com/ros-simulation/gazebo_ros_pkgs/pull/462 (see [drcsim PR 544](https://bitbucket.org/osrf/drcsim/pull-requests/544/added-example-scripts-that-use-the-gazebo/diff)) for example usage). A launch file will be added to `val_gazebo` in a separate pull request.