### PR TITLE
valkyrie_base_sim.xacro: enable self_collide

### DIFF
--- a/model/robots/common/xacro/valkyrie_base_sim.xacro
+++ b/model/robots/common/xacro/valkyrie_base_sim.xacro
@@ -6,6 +6,17 @@
       </plugin>
     </gazebo>
 
+    <gazebo>
+      <self_collide>true</self_collide>
+    </gazebo>
+
+    <gazebo reference="leftHipRollLink">
+      <self_collide>false</self_collide>
+    </gazebo>
+    <gazebo reference="rightHipRollLink">
+      <self_collide>false</self_collide>
+    </gazebo>
+
     <xacro:make_pelvis />
     <xacro:make_waist waist_root_link="${Pelvis_Link_Name}" />
     <xacro:make_head head_root_link="${TorsoRollLinkName}" />


### PR DESCRIPTION
It always bothered me that the arms and legs of atlas did not collide with each other in the VRC. This PR enables self-collide for all the links in the Valkyrie sim, except the `HipRollLinks`, which appear to interfere with the pelvis and make the legs go crazy. Fixing the meshes might help, but it's pretty easy to just disable self-collide for those `HipRollLinks` in the meantime.

It's easy to test; just load `val_sim_harnessed.launch` and press play, the arms and legs will now hit each other instead of ghosting.